### PR TITLE
Add mock database testing agent

### DIFF
--- a/src/llm/parsers.py
+++ b/src/llm/parsers.py
@@ -95,6 +95,17 @@ class ReviseOutput(BaseModel):
     chain_of_thought_reasoning: str = Field(description="Your thought process on how you arrived at the final SQL query.")
     revised_SQL: str = Field(description="The revised SQL query in a single string.")
 
+
+class MockDatabaseGeneratorOutput(BaseModel):
+    """Output model for mock database generation."""
+    sql_statements: List[str] = Field(description="SQL statements to create tables and insert rows.")
+    satisfying_rows: Dict[str, Any] = Field(description="Description of the rows that satisfy the question conditions.")
+
+
+class MockAnswerOutput(BaseModel):
+    """Output model for mock answer generation."""
+    attributes: List[str] = Field(description="Column names of the answer table.")
+    values: List[List[Any]] = Field(description="Rows of the answer table.")
     
 class GenerateCandidateGeminiMarkDownParserCOT(BaseOutputParser):
     """Parses output embedded in markdown code blocks containing SQL queries."""
@@ -384,7 +395,9 @@ def get_parser(parser_name: str) -> BaseOutputParser:
         "generate_unit_tests": TestCaseGenerationOutput(),
         "reverse_question": PlainTextOrJSONQuestionParser(),
         "similarity_judge": SimilarityJudgeParser(),
-        "esql_question_enrichment": ESQLQuestionEnrichmentParser()
+        "esql_question_enrichment": ESQLQuestionEnrichmentParser(),
+        "mock_database_generator": lambda: JsonOutputParser(pydantic_object=MockDatabaseGeneratorOutput),
+        "mock_answer_generator": lambda: JsonOutputParser(pydantic_object=MockAnswerOutput),
     }
 
     if parser_name not in parser_configs:

--- a/src/workflow/agents/mock_database_tester/mock_database_tester.py
+++ b/src/workflow/agents/mock_database_tester/mock_database_tester.py
@@ -1,0 +1,24 @@
+from workflow.agents.agent import Agent
+
+from .tool_kit.mock_database_generator import MockDatabaseGenerator
+from .tool_kit.mock_answer_generator import MockAnswerGenerator
+from .tool_kit.decision import Decision
+
+
+class MockDatabaseTester(Agent):
+    """Agent that builds a mock database and selects the correct SQL."""
+
+    def __init__(self, config: dict):
+        super().__init__(
+            name="Mock Database Tester",
+            task=(
+                "create a mock database, derive the expected answer, and choose the SQL that matches the answer",
+                "generate a mock database, compute the expected answer, and pick the candidate SQL that returns it",
+            ),
+            config=config,
+        )
+        self.tools = {
+            "mock_database_generator": MockDatabaseGenerator(**config["tools"]["mock_database_generator"]),
+            "mock_answer_generator": MockAnswerGenerator(**config["tools"]["mock_answer_generator"]),
+            "decision": Decision(),
+        }

--- a/src/workflow/agents/mock_database_tester/tool_kit/decision.py
+++ b/src/workflow/agents/mock_database_tester/tool_kit/decision.py
@@ -1,0 +1,44 @@
+from typing import Dict, Any, List, Tuple
+import sqlite3
+
+from workflow.system_state import SystemState
+from workflow.agents.tool import Tool
+from workflow.sql_meta_info import SQLMetaInfo
+
+
+class Decision(Tool):
+    """Select the candidate SQL matching the mock answer."""
+
+    def __init__(self):
+        super().__init__()
+        self.selected_sql: str | None = None
+
+    def _run(self, state: SystemState):
+        expected = [tuple(row) for row in state.mock_answer.get("values", [])]
+        expected_set = set(expected)
+        candidates: List[str] = []
+        for metas in state.SQL_meta_infos.values():
+            for meta in metas:
+                candidates.append(meta.SQL)
+        conn = sqlite3.connect(state.mock_db_path)
+        cursor = conn.cursor()
+        for sql in candidates:
+            try:
+                cursor.execute(sql)
+                result = cursor.fetchall()
+                if set(result) == expected_set:
+                    self.selected_sql = sql
+                    break
+            except Exception:
+                continue
+        conn.close()
+        if self.selected_sql:
+            state.SQL_meta_infos[self.tool_name] = [SQLMetaInfo(SQL=self.selected_sql)]
+        else:
+            state.errors[self.tool_name] = "No candidate SQL matched the expected answer"
+
+    def _get_updates(self, state: SystemState) -> Dict[str, Any]:
+        return {
+            "node_type": self.tool_name,
+            "selected_sql": self.selected_sql,
+        }

--- a/src/workflow/agents/mock_database_tester/tool_kit/mock_answer_generator.py
+++ b/src/workflow/agents/mock_database_tester/tool_kit/mock_answer_generator.py
@@ -1,0 +1,55 @@
+from typing import Dict, Any, List
+import sqlite3
+from pydantic import BaseModel
+
+from llm.models import call_llm_chain, get_llm_chain
+from llm.prompts import get_prompt
+from llm.parsers import get_parser
+from workflow.system_state import SystemState
+from workflow.agents.tool import Tool
+
+
+class MockAnswerGenerator(Tool):
+    """Generate the expected answer table for the mock database."""
+
+    class Config(BaseModel):
+        template_name: str
+        engine_config: Dict[str, Any]
+        parser_name: str
+
+    def __init__(self, **kwargs: Any):
+        super().__init__()
+        self.config = self.Config(**kwargs)
+        self.answer: Dict[str, Any] = {}
+
+    def _run(self, state: SystemState):
+        request_kwargs = {
+            "QUESTION": state.task.question,
+            "SATISFYING_ROWS": state.satisfying_rows,
+        }
+        response = call_llm_chain(
+            prompt=get_prompt(template_name=self.config.template_name),
+            engine=get_llm_chain(**self.config.engine_config),
+            parser=get_parser(self.config.parser_name),
+            request_kwargs=request_kwargs,
+            step=f"{self.tool_name}",
+        )
+        self.answer = response
+
+        conn = sqlite3.connect(state.mock_db_path)
+        cursor = conn.cursor()
+        cursor.execute("DROP TABLE IF EXISTS answer")
+        cols = ", ".join([f"{c} TEXT" for c in self.answer.get("attributes", [])])
+        cursor.execute(f"CREATE TABLE answer ({cols})")
+        for row in self.answer.get("values", []):
+            placeholders = ",".join(["?" for _ in row])
+            cursor.execute(f"INSERT INTO answer VALUES ({placeholders})", row)
+        conn.commit()
+        conn.close()
+        state.mock_answer = self.answer
+
+    def _get_updates(self, state: SystemState) -> Dict[str, Any]:
+        return {
+            "node_type": self.tool_name,
+            "answer": self.answer,
+        }

--- a/src/workflow/agents/mock_database_tester/tool_kit/mock_database_generator.py
+++ b/src/workflow/agents/mock_database_tester/tool_kit/mock_database_generator.py
@@ -1,0 +1,64 @@
+from typing import Dict, Any, List
+import sqlite3
+import tempfile
+
+from pydantic import BaseModel
+
+from llm.models import call_llm_chain, get_llm_chain
+from llm.prompts import get_prompt
+from llm.parsers import get_parser
+from workflow.system_state import SystemState
+from workflow.agents.tool import Tool
+
+
+class MockDatabaseGenerator(Tool):
+    """Generate a small mock database based on schema and question."""
+
+    class Config(BaseModel):
+        template_name: str
+        engine_config: Dict[str, Any]
+        parser_name: str
+
+    def __init__(self, **kwargs: Any):
+        super().__init__()
+        self.config = self.Config(**kwargs)
+        self.generated_sql: List[str] = []
+        self.satisfying_rows: Dict[str, Any] = {}
+
+    def _run(self, state: SystemState):
+        request_kwargs = {
+            "DATABASE_SCHEMA": state.get_schema_string(schema_type="complete"),
+            "QUESTION": state.task.question,
+        }
+        response = call_llm_chain(
+            prompt=get_prompt(template_name=self.config.template_name),
+            engine=get_llm_chain(**self.config.engine_config),
+            parser=get_parser(self.config.parser_name),
+            request_kwargs=request_kwargs,
+            step=f"{self.tool_name}",
+        )
+        self.generated_sql = response.get("sql_statements", [])
+        self.satisfying_rows = response.get("satisfying_rows", {})
+
+        # Create temporary database and execute statements
+        tmp = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+        db_path = tmp.name
+        tmp.close()
+        conn = sqlite3.connect(db_path)
+        try:
+            cursor = conn.cursor()
+            for stmt in self.generated_sql:
+                cursor.execute(stmt)
+            conn.commit()
+        finally:
+            conn.close()
+        state.mock_db_path = db_path
+        state.mock_db_sqls = self.generated_sql
+        state.satisfying_rows = self.satisfying_rows
+
+    def _get_updates(self, state: SystemState) -> Dict[str, Any]:
+        return {
+            "node_type": self.tool_name,
+            "mock_db_path": state.mock_db_path,
+            "sql_count": len(self.generated_sql),
+        }

--- a/src/workflow/system_state.py
+++ b/src/workflow/system_state.py
@@ -34,6 +34,12 @@ class SystemState(BaseModel):
     reverse_questions: Dict[str, List[str]] = {}
     enriched_initial_question: str = ""
     errors: Dict[str, str] = {}
+
+    # Fields used by the mock database agent
+    mock_db_path: str = ""
+    mock_db_sqls: List[str] = []
+    satisfying_rows: Dict[str, Any] = {}
+    mock_answer: Dict[str, Any] = {}
     
     def add_columns_to_tentative_schema(self, selected_columns: Dict[str, List[str]]) -> None:
         """

--- a/src/workflow/team_builder.py
+++ b/src/workflow/team_builder.py
@@ -9,6 +9,7 @@ from workflow.agents.schema_selector.schema_selector import SchemaSelector
 from workflow.agents.candidate_generator.candidate_generator import CandidateGenerator
 from workflow.agents.unit_tester.unit_tester import UnitTester
 from workflow.agents.reverse_tester.reverse_tester import ReverseTester
+from workflow.agents.mock_database_tester.mock_database_tester import MockDatabaseTester
 
 from workflow.agents.evaluation import ExecutionAccuracy
 
@@ -17,7 +18,8 @@ AGENT_CLASSES = {
     "schema_selector": SchemaSelector,
     "candidate_generator": CandidateGenerator,
     "unit_tester": UnitTester,
-    "reverse_tester": ReverseTester
+    "reverse_tester": ReverseTester,
+    "mock_database_tester": MockDatabaseTester,
 }
 
 class CHESSTeamBuilder:

--- a/templates/template_mock_answer_generator.txt
+++ b/templates/template_mock_answer_generator.txt
@@ -1,0 +1,10 @@
+You are given a question and a description of rows in a mock database that satisfy it.
+Determine the expected answer table for the question and output it as JSON with:
+- "attributes": list of column names in the answer table.
+- "values": list of rows, each row is a list of values.
+
+Question:
+{QUESTION}
+
+Satisfying Rows:
+{SATISFYING_ROWS}

--- a/templates/template_mock_database_generator.txt
+++ b/templates/template_mock_database_generator.txt
@@ -1,0 +1,13 @@
+You are given a database schema and a natural language question.
+Create SQL statements that build a small mock database able to answer the question.
+Include CREATE TABLE and INSERT statements. Insert a few rows that satisfy the question
+conditions and additional rows (up to a total of 30 per table) that do not.
+Return the result as JSON with keys:
+- "sql_statements": list of SQL statements to execute sequentially.
+- "satisfying_rows": description of the rows that satisfy the question.
+
+Database Schema:
+{DATABASE_SCHEMA}
+
+Question:
+{QUESTION}


### PR DESCRIPTION
## Summary
- add MockDatabaseTester agent with tools to build a mock database, derive expected answers and choose correct SQL
- extend parsers and system state to support mock database generation
- wire new agent into team builder and add prompt templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` (fails: ModuleNotFoundError: No module named 'llm')


------
https://chatgpt.com/codex/tasks/task_e_68bd8bb2eb34832d885f4a3ca73f61be